### PR TITLE
Add missing Dependencies file in `project` folder

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,7 @@
+import sbt._
+
+object Dependencies {
+  val purecsv = "com.github.melrief" %% "purecsv" % "0.1.1"
+  val matryoshka = "com.slamdata" %% "matryoshka-core" % "0.18.3"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4"
+}


### PR DESCRIPTION
This PR adds the missing `Dependencies.scala` file that defines the project's dependencies. Without this file sbt fails to load.